### PR TITLE
Read inline source maps without trailing newline

### DIFF
--- a/lib/extractor.coffee
+++ b/lib/extractor.coffee
@@ -1,7 +1,7 @@
 # Gratefully stolen from https://gist.github.com/pmuellr/5143384
 path = require "path"
 
-sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json;base64,(.*)\n/
+sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json;base64,(.*)$/
 
 translateSources = (sources, grunt) ->
   newSources = []


### PR DESCRIPTION
Some inline source maps (e.g., those produced by ngAnnotate) don't have a trailing newline. This patch makes it work for such source maps.