### PR TITLE
Fix sourceMapCommentRegEx: allow url that have charset

### DIFF
--- a/lib/extractor.coffee
+++ b/lib/extractor.coffee
@@ -1,7 +1,7 @@
 # Gratefully stolen from https://gist.github.com/pmuellr/5143384
 path = require "path"
 
-sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json;(?:charset:[^;]+)?;base64,(.*)\n/
+sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json(?:;charset:[^;]+)?;base64,(.*)\n/
 
 translateSources = (sources, grunt) ->
   newSources = []

--- a/lib/extractor.coffee
+++ b/lib/extractor.coffee
@@ -1,7 +1,7 @@
 # Gratefully stolen from https://gist.github.com/pmuellr/5143384
 path = require "path"
 
-sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json;base64,(.*)\n/
+sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json;(?:charset:[^;]+)?;base64,(.*)\n/
 
 translateSources = (sources, grunt) ->
   newSources = []


### PR DESCRIPTION
Browserify add "charset:utf-8;" to the url.