### PR TITLE
Allow `charset=` and `charset:` in comment regexp

### DIFF
--- a/lib/extractor.coffee
+++ b/lib/extractor.coffee
@@ -1,7 +1,7 @@
 # Gratefully stolen from https://gist.github.com/pmuellr/5143384
 path = require "path"
 
-sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json(?:;charset:[^;]+)?;base64,(.*)\n/
+sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json(?:;charset[:=][^;]+)?;base64,(.*)\n/
 
 translateSources = (sources, grunt) ->
   newSources = []


### PR DESCRIPTION
In Browserify 12.0.0 the "charset:" statement of the `sourceMappingURL` comment was changed to "charset=", as explained in its [changelog](https://github.com/substack/node-browserify/blob/master/changelog.markdown#1200):

_Sourcemaps charset now uses an `=` instead of a `:`. This fixes certain issues with Chinese characters in sourcemaps. See #753._

The `sourceMapCommentRegEx` variable should be changed to reflect this modification. Otherwise, no source map will be found on files created with recent versions of Browserify..
