### PR TITLE
Uglify js 'inline' support

### DIFF
--- a/lib/extractor.coffee
+++ b/lib/extractor.coffee
@@ -1,7 +1,7 @@
 # Gratefully stolen from https://gist.github.com/pmuellr/5143384
 path = require "path"
 
-sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json(?:;charset[:=][^;]+)?;base64,(.*)\n/
+sourceMapCommentRegEx =  /\/\/[@#] sourceMappingURL=data:application\/json(?:;charset[:=][^;]+)?;base64,(.*)\n?/
 
 translateSources = (sources, grunt) ->
   newSources = []


### PR DESCRIPTION
### Description
When using Uglify Js `url: 'inline'` option it does not append a new line. 

### Solution
Adjust the `sourceMapCommentRegEx` to check on **optional new line**